### PR TITLE
Removed hardcoded references to 50 LEDs

### DIFF
--- a/src/leds/Leds.py
+++ b/src/leds/Leds.py
@@ -45,3 +45,6 @@ class Leds:
 
     def clear(self):
         self.setLeds([off])
+
+    def getNumber(self) -> int:
+        return LED_COUNT

--- a/src/patterns/__init__.py
+++ b/src/patterns/__init__.py
@@ -77,7 +77,7 @@ class StateWithRunMethod(State):
         self._args = args
 
     def run(self, leds: Leds, shouldStop: Callable[[], bool]):
-        pattern = self._patternManager(50, **self._args)
+        pattern = self._patternManager(leds.getNumber(), **self._args)
 
         while not shouldStop():
             leds.setLeds(pattern.tick())

--- a/src/patterns/fireflies/FirefliesConstant.py
+++ b/src/patterns/fireflies/FirefliesConstant.py
@@ -44,7 +44,7 @@ class FirefliesConstant:
 
     def _addMoreFireflies(self):
         takenPositions: Set[int] = set([ff.getPosition() for ff in self.fireflies])
-        emptyPositions: List[int] = list(filter(lambda x: x not in takenPositions, range(50)))
+        emptyPositions: List[int] = list(filter(lambda x: x not in takenPositions, range(self._numberOfBulbs)))
         shuffle(emptyPositions)
 
         numberOfNewFireflies = randrange(1, 5)

--- a/src/patterns/flickering_fairylights/helpers.py
+++ b/src/patterns/flickering_fairylights/helpers.py
@@ -67,8 +67,6 @@ def generateFullListOfColours(flickerBulbStates: List[BulbState]):
         on,
     ]
 
-    assert len(bulbs) == 50
-
     return bulbs
 
 


### PR DESCRIPTION
Removes references to `50` so that it's easier to add extra strings of fairylights